### PR TITLE
Review

### DIFF
--- a/src/renderer/components/FormComponents/Form/index.tsx
+++ b/src/renderer/components/FormComponents/Form/index.tsx
@@ -1,11 +1,11 @@
 import React, {FC} from 'react';
 import {Form as FormikForm, Formik} from 'formik';
-import {GenericFormOnSubmit, GenericFormValues} from '@renderer/types/forms';
+import {GenericFormValues} from '@renderer/types/forms';
 
 interface ComponentProps {
   className?: string;
   initialValues?: GenericFormValues;
-  onSubmit: GenericFormOnSubmit;
+  onSubmit(values: GenericFormValues): void | Promise<any>;
   validationSchema?: any;
 }
 

--- a/src/renderer/components/Modal/Modal.scss
+++ b/src/renderer/components/Modal/Modal.scss
@@ -8,10 +8,14 @@
 }
 
 .Modal {
+  background: var(--color-white);
   border-radius: 3px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
-  background: var(--color-white);
+  left: 50%;
   position: fixed;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 324px;
 
   &__overlay {
     animation: addOverlay 0.3s forwards;
@@ -62,11 +66,11 @@
   }
 
   &__footer {
-    height: 60px;
-    padding: 0 12px;
-    display: flex;
-    justify-content: flex-end;
     align-items: center;
+    display: flex;
+    height: 60px;
+    justify-content: flex-end;
+    padding: 0 12px;
   }
 
   &__default-submit {

--- a/src/renderer/components/Modal/index.tsx
+++ b/src/renderer/components/Modal/index.tsx
@@ -16,51 +16,35 @@ export interface ModalButtonProps extends FormButtonProps {
   content: ReactNode;
 }
 
-// Usage Guide
-// --
-// use `header` or `title` prop to render the header
-// use 'footer' or ( 'submitButtonContent' | 'cancelButtonContent' ) prop to render the footer
-// --
 interface ModalProps {
   cancelButton?: ModalButtonProps;
   className?: string;
+  close(): void;
+  displayCancelButton?: boolean;
+  displaySubmitButton?: boolean;
   footer?: ReactNode;
   header?: ReactNode;
-  hideCancelButton?: boolean;
-  hideSubmitButton?: boolean;
   initialValues?: GenericFormValues;
   onSubmit: GenericFunction;
-  open: boolean;
-  close(): void;
   style?: CSSProperties;
-  submitting?: boolean;
   submitButton?: ModalButtonProps;
-  title?: string;
+  submitting?: boolean;
 }
-
-const defaultModalStyle: CSSProperties = {
-  left: '50%',
-  top: '50%',
-  transform: 'translate(-50%, -50%)',
-  width: 324,
-};
 
 const Modal: FC<ModalProps> = ({
   cancelButton,
   children,
   className,
   close,
+  displayCancelButton = true,
+  displaySubmitButton = true,
   footer,
   header,
-  hideCancelButton = false,
-  hideSubmitButton = false,
   initialValues = {},
   onSubmit,
-  open,
-  style = defaultModalStyle,
-  submitting = false,
+  style = {},
   submitButton,
-  title,
+  submitting = false,
 }) => {
   const ignoreDirty = useMemo<boolean>(() => Object.keys(initialValues).length === 0, [initialValues]);
   const cancelProps = useMemo<ModalButtonProps>(
@@ -94,7 +78,7 @@ const Modal: FC<ModalProps> = ({
   const renderDefaultFooter = (): ReactNode => {
     return (
       <>
-        {!hideCancelButton && (
+        {displayCancelButton && (
           <FormButton
             className={clsx('Modal__default-cancel', cancelProps.className)}
             color={cancelProps.color}
@@ -108,7 +92,7 @@ const Modal: FC<ModalProps> = ({
             {cancelProps.content}
           </FormButton>
         )}
-        {!hideSubmitButton && (
+        {displaySubmitButton && (
           <FormButton
             className={clsx('Modal__default-submit', submitProps.className)}
             color={submitProps.color}
@@ -126,24 +110,22 @@ const Modal: FC<ModalProps> = ({
     );
   };
 
-  return open
-    ? createPortal(
-        <>
-          <div className={clsx('Modal__overlay', {submitting})} onClick={submitting ? noop : close} />
-          <div className={clsx('Modal', className)} style={style}>
-            <div className="Modal__header">
-              {header || <h2>{title}</h2>}
-              <Icon className={clsx('Icon__close', {submitting})} disabled={submitting} icon="close" onClick={close} />
-            </div>
-            <Form initialValues={initialValues} onSubmit={onSubmit}>
-              <div className="Modal__content">{children}</div>
-              <div className="Modal__footer">{footer || renderDefaultFooter()}</div>
-            </Form>
-          </div>
-        </>,
-        document.getElementById('modal-root')!,
-      )
-    : null;
+  return createPortal(
+    <>
+      <div className={clsx('Modal__overlay', {submitting})} onClick={submitting ? noop : close} />
+      <div className={clsx('Modal', className)} style={style}>
+        <div className="Modal__header">
+          {typeof header === 'string' ? <h2>{header}</h2> : header}
+          <Icon className={clsx('Icon__close', {submitting})} disabled={submitting} icon="close" onClick={close} />
+        </div>
+        <Form initialValues={initialValues} onSubmit={onSubmit}>
+          <div className="Modal__content">{children}</div>
+          <div className="Modal__footer">{footer || renderDefaultFooter()}</div>
+        </Form>
+      </div>
+    </>,
+    document.getElementById('modal-root')!,
+  );
 };
 
 export default Modal;

--- a/src/renderer/containers/Bank/EditBankModal/index.tsx
+++ b/src/renderer/containers/Bank/EditBankModal/index.tsx
@@ -9,14 +9,13 @@ import './EditBankModal.scss';
 
 interface ComponentProps {
   close(): void;
-  open: boolean;
 }
 
 const initialValues = {name: '', type: ''};
 
 type Values = typeof initialValues;
 
-const EditBankModal: FC<ComponentProps> = ({close, open}) => {
+const EditBankModal: FC<ComponentProps> = ({close}) => {
   const [submitting, , setSubmittingTrue, setSubmittingFalse] = useBooleanState(false);
 
   const handleSubmit = (values: Values) => {
@@ -63,9 +62,8 @@ const EditBankModal: FC<ComponentProps> = ({close, open}) => {
       header={renderHeader()}
       initialValues={initialValues}
       onSubmit={handleSubmit}
-      open={open}
       submitting={submitting}
-      style={{left: '100px', top: '30px', width: 500}}
+      style={{left: '100px', top: '30px', transform: 'none', width: 500}}
     >
       <p>
         Here is a bs form. Most of the modal's logic can be contained in a component like this, instead of polluting the

--- a/src/renderer/containers/Bank/index.tsx
+++ b/src/renderer/containers/Bank/index.tsx
@@ -56,6 +56,30 @@ const Bank = () => {
     </>
   );
 
+  const renderDeleteModal = () => (
+    <Modal
+      cancelButton={{content: 'No'}}
+      className="Bank__DeleteModal"
+      close={toggleDeleteModal}
+      header={
+        <>
+          <Icon className="Icon__warning" icon="warning" />
+          <h2 className="Modal__title">Delete Account</h2>
+        </>
+      }
+      onSubmit={handleDeleteAccountFromModal}
+      submitButton={{content: 'Yes'}}
+      submitting={submittingDeleteModal}
+    >
+      <>
+        <span className="delete-warning-span">Warning: </span> If you delete your account, you will lose all the points
+        in your account as well as your signing key. Are you sure you want to delete your account?
+      </>
+    </Modal>
+  );
+
+  const renderEditBankModal = () => <EditBankModal close={toggleEditModal} />;
+
   const renderLeftTools = () => {
     return (
       <>
@@ -106,39 +130,19 @@ const Bank = () => {
     </>
   );
 
+  const renderUnregisterBankModal = () => (
+    <Modal close={toggleUnregisterBankModal} header="Unregister Bank" onSubmit={toggleUnregisterBankModal}>
+      Here is the modal used very minimally. It is using most of modal's defaults, and it's not using any custom header
+      or footer
+    </Modal>
+  );
+
   return (
     <div className="Bank">
       <PageLayout content={renderContent()} top={renderTop()} />
-      <Modal
-        cancelButton={{content: 'No'}}
-        className="Bank__DeleteModal"
-        close={toggleDeleteModal}
-        header={
-          <>
-            <Icon className="Icon__warning" icon="warning" />
-            <h2 className="Modal__title">Delete Account</h2>
-          </>
-        }
-        onSubmit={handleDeleteAccountFromModal}
-        open={deleteModalIsOpen}
-        submitButton={{content: 'Yes'}}
-        submitting={submittingDeleteModal}
-      >
-        <>
-          <span className="delete-warning-span">Warning: </span> If you delete your account, you will lose all the
-          points in your account as well as your signing key. Are you sure you want to delete your account?
-        </>
-      </Modal>
-      <Modal
-        onSubmit={toggleUnregisterBankModal}
-        open={unregisterBankModalIsOpen}
-        close={toggleUnregisterBankModal}
-        title="Unregister Bank"
-      >
-        Here is the modal used very minimally. It is using most of modal's defaults, and it's not using any custom
-        header or footer
-      </Modal>
-      <EditBankModal close={toggleEditModal} open={editModalIsOpen} />
+      {deleteModalIsOpen && renderDeleteModal()}
+      {editModalIsOpen && renderEditBankModal()}
+      {unregisterBankModalIsOpen && renderUnregisterBankModal()}
     </div>
   );
 };

--- a/src/renderer/hooks/useBooleanState.tsx
+++ b/src/renderer/hooks/useBooleanState.tsx
@@ -5,13 +5,10 @@ const useBooleanState = (initialValue: boolean): [boolean, () => void, () => voi
 
   const setFalse = (): void => {
     setState(false);
-    // console.log('STATE', state);
-    // if (state) setState(false);
   };
 
   const setTrue = (): void => {
     setState(true);
-    // if (!state) setState(true);
   };
 
   const toggleState = (): void => {


### PR DESCRIPTION
- `GenericFormOnSubmit` didn't exist, removed
- renamed `hideCancelButton` to `displayCancelButton` to simplify readability of "not hide"
- removed `open` prop for modal (if not open then don't render)
- removed `title` prop for modal (accept string as header instead) - also avoid usage of passing in both `header` and `title` prop
- move `defaultModalStyle` from component to scss to clean up component (doubt we will have many non-centered modals anyways)

