### PR TITLE
Added JEST for unit testing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["@babel/preset-react", "@babel/preset-typescript"],
-  "plugins": ["react-hot-loader/babel"]
-}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,5 +3,8 @@
   "plugins": ["prettier"],
   "rules": {
     "prettier/prettier": ["error"]
+  },
+  "env": {
+    "jest": true
   }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
+  plugins: ['react-hot-loader/babel'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,20 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  modulePaths: ['node_modules', '<rootDir>/src', '<rootDir>'],
+  // An array of directory names to be searched recursively up from the requiring module's location
+  moduleDirectories: ['<rootDir>/node_modules', '<rootDir>/src'],
+
+  // An array of file extensions your modules use
+  moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'scss'],
+
+  // A map from regular expressions to module names that allow to stub out resources with a single module
+  moduleNameMapper: {
+    '^.+\\.(css|less|scss)$': 'identity-obj-proxy',
+  },
+  transform: {
+    '^.+\\.js$': 'babel-jest',
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint --ext .ts ."
+    "lint": "eslint --ext .ts .",
+    "test": "jest"
   },
   "keywords": [],
   "author": {
@@ -69,6 +70,9 @@
     ]
   },
   "devDependencies": {
+    "@babel/core": "^7.10.5",
+    "@babel/preset-env": "^7.10.4",
+    "@babel/preset-typescript": "^7.10.4",
     "@electron-forge/cli": "6.0.0-beta.51",
     "@electron-forge/maker-deb": "6.0.0-beta.51",
     "@electron-forge/maker-rpm": "6.0.0-beta.51",
@@ -87,6 +91,7 @@
     "@types/yup": "^0.29.2",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",
+    "babel-jest": "^26.1.0",
     "babel-loader": "^8.1.0",
     "css-loader": "^3.5.3",
     "electron": "9.0.0",
@@ -101,12 +106,15 @@
     "eslint-plugin-react-hooks": "^2.5.1",
     "fork-ts-checker-webpack-plugin": "^3.1.1",
     "husky": "^4.2.5",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^26.1.0",
     "lint-staged": "^10.2.9",
     "node-loader": "^0.6.0",
     "node-sass": "^4.14.1",
     "prettier": "^2.0.5",
     "sass-loader": "^8.0.2",
     "style-loader": "^0.23.1",
+    "ts-jest": "^26.1.3",
     "ts-loader": "^6.2.2",
     "typescript": "^3.9.5"
   },

--- a/src/renderer/utils/format.test.js
+++ b/src/renderer/utils/format.test.js
@@ -1,0 +1,15 @@
+import {formatAddress} from './format.ts';
+
+describe('formatAddress to return the following: ', () => {
+  test('correct IP without port when port 80 is passed', () => {
+    expect(formatAddress('127.0.0.1', '80', 'http')).toBe('http://127.0.0.1');
+  });
+
+  test('correct IP with port when some other port is passed', () => {
+    expect(formatAddress('127.0.0.1', '8081', 'http')).toBe('http://127.0.0.1:8081');
+  });
+
+  test('URL with FILE protocol, when no protocol is passed', () => {
+    expect(formatAddress('127.0.0.1', '8081')).toBe('file://127.0.0.1:8081');
+  });
+});

--- a/src/renderer/utils/format.ts
+++ b/src/renderer/utils/format.ts
@@ -1,4 +1,4 @@
-export const formatAddress = (ipAddress: string, port: string|null, protocol:string) => {
-  const _port = (port && port !== '80') ? `:${port}` : '';
+export const formatAddress = (ipAddress: string, port: string | null, protocol: string = 'file') => {
+  const _port = port && port !== '80' ? `:${port}` : '';
   return `${protocol}://${ipAddress}${_port}`;
-}
+};


### PR DESCRIPTION
In reference to : https://github.com/thenewboston-developers/Account-Manager/issues/54 

Changes: 
- Added Jest for unit testing, installed the required dependencies as devDependencies

- Deprecated `.babelrc` in favor or `babel.config.js` as recommended by [Babel](https://babeljs.io/docs/en/configuration)

- Added unit test for `utils/format.ts` in `format.test.js`
