### PR TITLE
Loader pagination update

### DIFF
--- a/src/renderer/components/PageTable/index.tsx
+++ b/src/renderer/components/PageTable/index.tsx
@@ -2,10 +2,10 @@ import React, {FC, ReactNode, useState} from 'react';
 import clsx from 'clsx';
 
 import ArrowToggle from '@renderer/components/ArrowToggle';
+import Loader from '@renderer/components/FormElements/Loader';
 import {getCustomClassNames} from '@renderer/utils/components';
 
 import './PageTable.scss';
-import Loader from '@renderer/components/FormElements/Loader';
 
 interface Header {
   [tableKey: string]: string;

--- a/src/renderer/components/PageTable/index.tsx
+++ b/src/renderer/components/PageTable/index.tsx
@@ -5,6 +5,7 @@ import ArrowToggle from '@renderer/components/ArrowToggle';
 import {getCustomClassNames} from '@renderer/utils/components';
 
 import './PageTable.scss';
+import Loader from '@renderer/components/FormElements/Loader';
 
 interface Header {
   [tableKey: string]: string;
@@ -24,9 +25,10 @@ export interface PageTableItems {
 interface ComponentProps {
   className?: string;
   items: PageTableItems;
+  loading?: boolean;
 }
 
-const PageTable: FC<ComponentProps> = ({className, items}) => {
+const PageTable: FC<ComponentProps> = ({className, items, loading = false}) => {
   const {headers, data, orderedKeys} = items;
   const [expanded, setExpanded] = useState<number[]>([]);
 
@@ -64,7 +66,9 @@ const PageTable: FC<ComponentProps> = ({className, items}) => {
     });
   };
 
-  return (
+  return loading ? (
+    <Loader />
+  ) : (
     <table className={clsx('PageTable', className)}>
       <thead className={clsx('PageTable__thead', {...getCustomClassNames(className, '__thead', true)})}>
         <tr>

--- a/src/renderer/components/Pagination/index.tsx
+++ b/src/renderer/components/Pagination/index.tsx
@@ -24,18 +24,22 @@ const Pagination: FC<ComponentProps> = ({className, currentPage, setPage, totalP
     totalPages,
   ]);
 
-  const renderEllipses = useCallback((): ReactNode => {
-    return (
-      <div
-        className={clsx('Pagination__button Pagination__button--ellipses', {
-          ...getCustomClassNames(className, '__button', true),
-          ...getCustomClassNames(className, '__button--ellipses', true),
-        })}
-      >
-        ...
-      </div>
-    );
-  }, [className]);
+  const renderEllipses = useCallback(
+    (key: string): ReactNode => {
+      return (
+        <div
+          className={clsx('Pagination__button Pagination__button--ellipses', {
+            ...getCustomClassNames(className, '__button', true),
+            ...getCustomClassNames(className, '__button--ellipses', true),
+          })}
+          key={key}
+        >
+          ...
+        </div>
+      );
+    },
+    [className],
+  );
 
   const renderPage = useCallback(
     (page: number): ReactNode => {
@@ -46,6 +50,7 @@ const Pagination: FC<ComponentProps> = ({className, currentPage, setPage, totalP
             ...getCustomClassNames(className, '__button', true),
             ...getCustomClassNames(className, '__button--active', page === currentPage),
           })}
+          key={page}
           onClick={setPage(page)}
         >
           {page}
@@ -56,10 +61,10 @@ const Pagination: FC<ComponentProps> = ({className, currentPage, setPage, totalP
   );
 
   const renderMiddle = useCallback((): ReactNode => {
-    if (totalPages === 1) return null;
+    if (totalPages <= 1) return null;
 
     const pageNodes = [renderPage(1)];
-    if (leftEllipsesIsVisible) pageNodes.push(renderEllipses());
+    if (leftEllipsesIsVisible) pageNodes.push(renderEllipses('left'));
 
     const totalMiddleNumbers =
       TOTAL_VISIBLE_PAGES - 2 - (leftEllipsesIsVisible ? 1 : 0) - (rightEllipsesIsVisible ? 1 : 0);
@@ -73,13 +78,13 @@ const Pagination: FC<ComponentProps> = ({className, currentPage, setPage, totalP
       }
     }
 
-    if (rightEllipsesIsVisible) pageNodes.push(renderEllipses());
+    if (rightEllipsesIsVisible) pageNodes.push(renderEllipses('right'));
     pageNodes.push(renderPage(totalPages));
 
     return pageNodes;
   }, [currentPage, leftEllipsesIsVisible, renderEllipses, renderPage, rightEllipsesIsVisible, totalPages]);
 
-  if (totalPages === 1) return null;
+  if (totalPages <= 1) return null;
   return (
     <div className={clsx('Pagination', className)}>
       <Icon

--- a/src/renderer/config/index.ts
+++ b/src/renderer/config/index.ts
@@ -1,4 +1,4 @@
-export const PAGINATED_RESULTS_LIMIT = 5;
+export const PAGINATED_RESULTS_LIMIT = 30;
 
 export const defaultPaginatedQueryParam = {
   limit: PAGINATED_RESULTS_LIMIT,

--- a/src/renderer/config/index.ts
+++ b/src/renderer/config/index.ts
@@ -1,4 +1,4 @@
-export const PAGINATED_RESULTS_LIMIT = 30;
+export const PAGINATED_RESULTS_LIMIT = 5;
 
 export const defaultPaginatedQueryParam = {
   limit: PAGINATED_RESULTS_LIMIT,

--- a/src/renderer/containers/Account/AccountTransactions/index.tsx
+++ b/src/renderer/containers/Account/AccountTransactions/index.tsx
@@ -1,13 +1,14 @@
-import React, {FC, useEffect, useState} from 'react';
+import React, {FC, useMemo} from 'react';
 import {useSelector} from 'react-redux';
 import {useParams} from 'react-router-dom';
-import axios from 'axios';
-import noop from 'lodash/noop';
 
-import PageTable, {PageTableData} from '@renderer/components/PageTable';
+import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
+import {BANK_BANK_TRANSACTIONS} from '@renderer/constants';
+import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {getActiveBankConfig} from '@renderer/selectors';
-import {formatAddress} from '@renderer/utils/address';
+import {BankTransaction} from '@renderer/types';
+import {formatAddressFromNode} from '@renderer/utils/address';
 
 enum TableKeys {
   senderAccountNumber,
@@ -20,62 +21,53 @@ enum TableKeys {
 
 const AccountTransactions: FC = () => {
   const {accountNumber} = useParams();
-  const activeBank = useSelector(getActiveBankConfig);
-  const [bankTransactions, setBankTransactions] = useState<PageTableData[]>([]);
+  const activeBank = useSelector(getActiveBankConfig)!;
+  const activeBankAddress = formatAddressFromNode(activeBank);
+  const {currentPage, loading, results: bankTransactions, setPage, totalPages} = usePaginatedNetworkDataFetcher<
+    BankTransaction
+  >(BANK_BANK_TRANSACTIONS, activeBankAddress, {account_number: accountNumber});
 
-  useEffect(() => {
-    if (!activeBank) return;
+  const bankTransactionsTableData = useMemo<PageTableData[]>(
+    () =>
+      bankTransactions.map((bankTransaction) => ({
+        key: bankTransaction.id,
+        [TableKeys.amount]: bankTransaction.amount,
+        [TableKeys.balanceKey]: bankTransaction.block.balance_key,
+        [TableKeys.dateCreated]: bankTransaction.block.created_date,
+        [TableKeys.recipientAccountNumber]: bankTransaction.recipient,
+        [TableKeys.senderAccountNumber]: bankTransaction.block.sender,
+        [TableKeys.signature]: bankTransaction.block.signature,
+      })) || [],
+    [bankTransactions],
+  );
 
-    const fetchData = async (): Promise<void> => {
-      const {ip_address: ipAddress, port, protocol} = activeBank;
-      const address = formatAddress(ipAddress, port, protocol);
-      const {data} = await axios.get(`${address}/bank_transactions`, {
-        params: {
-          account_number: accountNumber,
-        },
-      });
-      const tableData = data.results.map(
-        (bankTransaction: any) =>
-          ({
-            key: bankTransaction.id,
-            [TableKeys.amount]: bankTransaction.amount,
-            [TableKeys.balanceKey]: bankTransaction.block.balance_key,
-            [TableKeys.dateCreated]: bankTransaction.block.created_date,
-            [TableKeys.recipientAccountNumber]: bankTransaction.recipient,
-            [TableKeys.senderAccountNumber]: bankTransaction.block.sender,
-            [TableKeys.signature]: bankTransaction.block.signature,
-          } as PageTableData),
-      );
-      setBankTransactions(tableData);
-    };
-
-    fetchData();
-  }, [accountNumber, activeBank]);
+  const pageTableItems = useMemo<PageTableItems>(
+    () => ({
+      data: bankTransactionsTableData,
+      headers: {
+        [TableKeys.amount]: 'Amount',
+        [TableKeys.balanceKey]: 'Balance Key',
+        [TableKeys.dateCreated]: 'Date Created',
+        [TableKeys.recipientAccountNumber]: 'Recipient Account Number',
+        [TableKeys.senderAccountNumber]: 'Sender Account Number',
+        [TableKeys.signature]: 'Signature',
+      },
+      orderedKeys: [
+        TableKeys.senderAccountNumber,
+        TableKeys.recipientAccountNumber,
+        TableKeys.amount,
+        TableKeys.balanceKey,
+        TableKeys.signature,
+        TableKeys.dateCreated,
+      ],
+    }),
+    [bankTransactionsTableData],
+  );
 
   return (
     <div className="AccountTransactions">
-      <PageTable
-        items={{
-          data: bankTransactions,
-          headers: {
-            [TableKeys.amount]: 'Amount',
-            [TableKeys.balanceKey]: 'Balance Key',
-            [TableKeys.dateCreated]: 'Date Created',
-            [TableKeys.recipientAccountNumber]: 'Recipient Account Number',
-            [TableKeys.senderAccountNumber]: 'Sender Account Number',
-            [TableKeys.signature]: 'Signature',
-          },
-          orderedKeys: [
-            TableKeys.senderAccountNumber,
-            TableKeys.recipientAccountNumber,
-            TableKeys.amount,
-            TableKeys.balanceKey,
-            TableKeys.signature,
-            TableKeys.dateCreated,
-          ],
-        }}
-      />
-      <Pagination currentPage={1} setPage={() => noop} totalPages={1} />
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/containers/App.tsx
+++ b/src/renderer/containers/App.tsx
@@ -12,18 +12,21 @@ import {getActiveBank, getActiveBankConfig} from '@renderer/selectors';
 import {AppDispatch} from '@renderer/types';
 
 const App: FC = () => {
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const dispatch = useDispatch<AppDispatch>();
   const activeBank = useSelector(getActiveBank);
   const activeBankConfig = useSelector(getActiveBankConfig);
 
   useEffect(() => {
     if (activeBank && !activeBankConfig) {
+      setLoading(true);
       const fetchData = async (): Promise<void> => {
         await dispatch(connect(activeBank));
         setLoading(false);
       };
       fetchData();
+    } else {
+      setLoading(false);
     }
   }, [activeBank, activeBankConfig, dispatch]);
 

--- a/src/renderer/containers/App.tsx
+++ b/src/renderer/containers/App.tsx
@@ -29,7 +29,7 @@ const App: FC = () => {
 
   const renderComponent = (): ReactNode => {
     if (loading) return null;
-    if (!activeBank) return <Connect />;
+    if (!activeBank || !activeBankConfig) return <Connect />;
     return <Layout />;
   };
 

--- a/src/renderer/containers/Bank/BankAccounts/index.tsx
+++ b/src/renderer/containers/Bank/BankAccounts/index.tsx
@@ -1,11 +1,10 @@
 import React, {FC, useMemo} from 'react';
 
 import AccountLink from '@renderer/components/AccountLink';
-import {Loader} from '@renderer/components/FormElements';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import {BANK_ACCOUNTS} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {BankAccount} from '@renderer/types';
 
 enum TableKeys {
@@ -17,9 +16,10 @@ enum TableKeys {
 }
 
 const BankAccounts: FC = () => {
+  const address = useAddress();
   const {currentPage, loading, results: bankAccounts, setPage, totalPages} = usePaginatedNetworkDataFetcher<
     BankAccount
-  >(BANK_ACCOUNTS);
+  >(BANK_ACCOUNTS, address);
 
   const bankAccountsTableData = useMemo<PageTableData[]>(
     () =>
@@ -57,14 +57,8 @@ const BankAccounts: FC = () => {
 
   return (
     <div className="BankAccounts">
-      {loading ? (
-        <Loader />
-      ) : (
-        <>
-          <PageTable items={pageTableItems} />
-          <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
-        </>
-      )}
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/containers/Bank/BankBanks/index.tsx
+++ b/src/renderer/containers/Bank/BankBanks/index.tsx
@@ -6,7 +6,7 @@ import NodeLink from '@renderer/components/NodeLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import {BANK_BANKS} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {Node} from '@renderer/types';
 
 enum TableKeys {
@@ -21,8 +21,10 @@ enum TableKeys {
 }
 
 const BankBanks: FC = () => {
+  const address = useAddress();
   const {currentPage, loading, results: bankBanks, setPage, totalPages} = usePaginatedNetworkDataFetcher<Node>(
     BANK_BANKS,
+    address,
   );
 
   const bankBanksTableData = useMemo<PageTableData[]>(

--- a/src/renderer/containers/Bank/BankBlocks/index.tsx
+++ b/src/renderer/containers/Bank/BankBlocks/index.tsx
@@ -1,11 +1,10 @@
 import React, {FC, useMemo} from 'react';
 
 import AccountLink from '@renderer/components/AccountLink';
-import {Loader} from '@renderer/components/FormElements';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import {BANK_BLOCKS} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {BlockResponse} from '@renderer/types';
 
 enum TableKeys {
@@ -18,9 +17,10 @@ enum TableKeys {
 }
 
 const BankBlocks: FC = () => {
+  const address = useAddress();
   const {currentPage, loading, results: bankBlocks, setPage, totalPages} = usePaginatedNetworkDataFetcher<
     BlockResponse
-  >(BANK_BLOCKS);
+  >(BANK_BLOCKS, address);
 
   const bankBlocksTableData = useMemo<PageTableData[]>(
     () =>
@@ -61,14 +61,8 @@ const BankBlocks: FC = () => {
 
   return (
     <div className="BankBlocks">
-      {loading ? (
-        <Loader />
-      ) : (
-        <>
-          <PageTable items={pageTableItems} />
-          <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
-        </>
-      )}
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/containers/Bank/BankConfirmationBlocks/index.tsx
+++ b/src/renderer/containers/Bank/BankConfirmationBlocks/index.tsx
@@ -1,10 +1,9 @@
 import React, {FC, useMemo} from 'react';
 
-import {Loader} from '@renderer/components/FormElements';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import {BANK_CONFIRMATION_BLOCKS} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {BankConfirmationBlock} from '@renderer/types';
 
 enum TableKeys {
@@ -15,9 +14,10 @@ enum TableKeys {
 }
 
 const BankConfirmationBlocks: FC = () => {
+  const address = useAddress();
   const {currentPage, loading, results: bankConfirmationBlocks, setPage, totalPages} = usePaginatedNetworkDataFetcher<
     BankConfirmationBlock
-  >(BANK_CONFIRMATION_BLOCKS);
+  >(BANK_CONFIRMATION_BLOCKS, address);
 
   const bankConfirmationBlocksTableData = useMemo<PageTableData[]>(
     () =>
@@ -47,14 +47,8 @@ const BankConfirmationBlocks: FC = () => {
 
   return (
     <div className="BankConfirmationBlocks">
-      {loading ? (
-        <Loader />
-      ) : (
-        <>
-          <PageTable items={pageTableItems} />
-          <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
-        </>
-      )}
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/containers/Bank/BankInvalidBlocks/index.tsx
+++ b/src/renderer/containers/Bank/BankInvalidBlocks/index.tsx
@@ -1,10 +1,9 @@
 import React, {FC, useMemo} from 'react';
 
-import {Loader} from '@renderer/components/FormElements';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import {BANK_INVALID_BLOCKS} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {InvalidBlock} from '@renderer/types';
 
 enum TableKeys {
@@ -15,9 +14,10 @@ enum TableKeys {
 }
 
 const BankInvalidBlocks: FC = () => {
+  const address = useAddress();
   const {currentPage, loading, results: bankInvalidBlocks, setPage, totalPages} = usePaginatedNetworkDataFetcher<
     InvalidBlock
-  >(BANK_INVALID_BLOCKS);
+  >(BANK_INVALID_BLOCKS, address);
 
   const bankInvalidBlockTableData = useMemo<PageTableData[]>(
     () =>
@@ -47,14 +47,8 @@ const BankInvalidBlocks: FC = () => {
 
   return (
     <div className="BankInvalidBlocks">
-      {loading ? (
-        <Loader />
-      ) : (
-        <>
-          <PageTable items={pageTableItems} />
-          <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
-        </>
-      )}
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/containers/Bank/BankTransactions/index.tsx
+++ b/src/renderer/containers/Bank/BankTransactions/index.tsx
@@ -1,11 +1,10 @@
 import React, {FC, useMemo} from 'react';
 
 import AccountLink from '@renderer/components/AccountLink';
-import {Loader} from '@renderer/components/FormElements';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import {BANK_BANK_TRANSACTIONS} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {BankTransaction} from '@renderer/types';
 
 enum TableKeys {
@@ -17,9 +16,10 @@ enum TableKeys {
 }
 
 const BankTransactions: FC = () => {
+  const address = useAddress();
   const {currentPage, loading, results: bankBankTransactions, setPage, totalPages} = usePaginatedNetworkDataFetcher<
     BankTransaction
-  >(BANK_BANK_TRANSACTIONS);
+  >(BANK_BANK_TRANSACTIONS, address);
 
   const bankBankTransactionsTableData = useMemo<PageTableData[]>(
     () =>
@@ -51,14 +51,8 @@ const BankTransactions: FC = () => {
 
   return (
     <div className="BankTransactions">
-      {loading ? (
-        <Loader />
-      ) : (
-        <>
-          <PageTable items={pageTableItems} />
-          <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
-        </>
-      )}
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/containers/Bank/BankValidatorConfirmationServices/index.tsx
+++ b/src/renderer/containers/Bank/BankValidatorConfirmationServices/index.tsx
@@ -1,10 +1,9 @@
 import React, {FC, useMemo} from 'react';
 
-import {Loader} from '@renderer/components/FormElements';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import {BANK_VALIDATOR_CONFIRMATION_SERVICES} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {ValidatorConfirmationService} from '@renderer/types';
 
 enum TableKeys {
@@ -17,13 +16,14 @@ enum TableKeys {
 }
 
 const BankValidatorConfirmationServices: FC = () => {
+  const address = useAddress();
   const {
     currentPage,
     loading,
     results: bankValidatorConfirmationServices,
     setPage,
     totalPages,
-  } = usePaginatedNetworkDataFetcher<ValidatorConfirmationService>(BANK_VALIDATOR_CONFIRMATION_SERVICES);
+  } = usePaginatedNetworkDataFetcher<ValidatorConfirmationService>(BANK_VALIDATOR_CONFIRMATION_SERVICES, address);
 
   const bankValidatorConfirmationServicesTableData = useMemo<PageTableData[]>(
     () =>
@@ -64,14 +64,8 @@ const BankValidatorConfirmationServices: FC = () => {
 
   return (
     <div className="BankValidatorConfirmationServices">
-      {loading ? (
-        <Loader />
-      ) : (
-        <>
-          <PageTable items={pageTableItems} />
-          <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
-        </>
-      )}
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/containers/Bank/BankValidators/index.tsx
+++ b/src/renderer/containers/Bank/BankValidators/index.tsx
@@ -1,12 +1,11 @@
 import React, {FC, useMemo} from 'react';
 
 import AccountLink from '@renderer/components/AccountLink';
-import {Loader} from '@renderer/components/FormElements';
 import NodeLink from '@renderer/components/NodeLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import {BANK_VALIDATORS} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {BaseValidator} from '@renderer/types';
 
 enum TableKeys {
@@ -25,9 +24,10 @@ enum TableKeys {
 }
 
 const BankValidators: FC = () => {
+  const address = useAddress();
   const {currentPage, loading, results: bankValidators, setPage, totalPages} = usePaginatedNetworkDataFetcher<
     BaseValidator
-  >(BANK_VALIDATORS);
+  >(BANK_VALIDATORS, address);
 
   const bankValidatorsTableData = useMemo<PageTableData[]>(
     () =>
@@ -86,14 +86,8 @@ const BankValidators: FC = () => {
 
   return (
     <div className="BankValidators">
-      {loading ? (
-        <Loader />
-      ) : (
-        <>
-          <PageTable items={pageTableItems} />
-          <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
-        </>
-      )}
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/containers/Validator/ValidatorAccounts/index.tsx
+++ b/src/renderer/containers/Validator/ValidatorAccounts/index.tsx
@@ -1,11 +1,10 @@
 import React, {FC, useMemo} from 'react';
 
 import AccountLink from '@renderer/components/AccountLink';
-import {Loader} from '@renderer/components/FormElements';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import {VALIDATOR_ACCOUNTS} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {ValidatorAccount} from '@renderer/types';
 
 enum TableKeys {
@@ -15,9 +14,10 @@ enum TableKeys {
 }
 
 const ValidatorAccounts: FC = () => {
+  const address = useAddress();
   const {currentPage, loading, results: validatorAccounts, setPage, totalPages} = usePaginatedNetworkDataFetcher<
     ValidatorAccount
-  >(VALIDATOR_ACCOUNTS);
+  >(VALIDATOR_ACCOUNTS, address);
 
   const validatorAccountsTableData = useMemo<PageTableData[]>(
     () =>
@@ -45,14 +45,8 @@ const ValidatorAccounts: FC = () => {
 
   return (
     <div className="ValidatorAccounts">
-      {loading ? (
-        <Loader />
-      ) : (
-        <>
-          <PageTable items={pageTableItems} />
-          <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
-        </>
-      )}
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/containers/Validator/ValidatorBanks/index.tsx
+++ b/src/renderer/containers/Validator/ValidatorBanks/index.tsx
@@ -1,11 +1,10 @@
 import React, {FC, useMemo} from 'react';
 
-import {Loader} from '@renderer/components/FormElements';
 import NodeLink from '@renderer/components/NodeLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import {VALIDATOR_BANKS} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {ValidatorBank} from '@renderer/types';
 
 enum TableKeys {
@@ -21,9 +20,10 @@ enum TableKeys {
 }
 
 const ValidatorBanks: FC = () => {
+  const address = useAddress();
   const {currentPage, loading, results: validatorBanks, setPage, totalPages} = usePaginatedNetworkDataFetcher<
     ValidatorBank
-  >(VALIDATOR_BANKS);
+  >(VALIDATOR_BANKS, address);
 
   const validatorAccountsTableData = useMemo<PageTableData[]>(
     () =>
@@ -73,14 +73,8 @@ const ValidatorBanks: FC = () => {
 
   return (
     <div className="ValidatorBanks">
-      {loading ? (
-        <Loader />
-      ) : (
-        <>
-          <PageTable items={pageTableItems} />
-          <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
-        </>
-      )}
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/containers/Validator/ValidatorValidators/index.tsx
+++ b/src/renderer/containers/Validator/ValidatorValidators/index.tsx
@@ -1,10 +1,9 @@
 import React, {FC, useMemo} from 'react';
 
-import {Loader} from '@renderer/components/FormElements';
 import NodeLink from '@renderer/components/NodeLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import {VALIDATOR_VALIDATORS} from '@renderer/constants';
-import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
+import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {BaseValidator} from '@renderer/types';
 import Pagination from '@renderer/components/Pagination';
 
@@ -24,9 +23,10 @@ enum TableKeys {
 }
 
 const ValidatorValidators: FC = () => {
+  const address = useAddress();
   const {currentPage, loading, results: validatorValidators, setPage, totalPages} = usePaginatedNetworkDataFetcher<
     BaseValidator
-  >(VALIDATOR_VALIDATORS);
+  >(VALIDATOR_VALIDATORS, address);
 
   const validatorValidatorsTableData = useMemo<PageTableData[]>(
     () =>
@@ -85,14 +85,8 @@ const ValidatorValidators: FC = () => {
 
   return (
     <div className="ValidatorValidators">
-      {loading ? (
-        <Loader />
-      ) : (
-        <>
-          <PageTable items={pageTableItems} />
-          <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
-        </>
-      )}
+      <PageTable items={pageTableItems} loading={loading} />
+      <Pagination currentPage={currentPage} setPage={setPage} totalPages={totalPages} />
     </div>
   );
 };

--- a/src/renderer/hooks/useAddress.tsx
+++ b/src/renderer/hooks/useAddress.tsx
@@ -4,7 +4,11 @@ import {formatAddress} from '@renderer/utils/address';
 
 const useAddress = (): string => {
   const {ipAddress, port, protocol} = useParams();
-  return useMemo(() => formatAddress(ipAddress, port, protocol), [ipAddress, port, protocol]);
+  return useMemo(() => (ipAddress && protocol ? formatAddress(ipAddress, port, protocol) : ''), [
+    ipAddress,
+    port,
+    protocol,
+  ]);
 };
 
 export default useAddress;


### PR DESCRIPTION
1) moved 'Loader' into the `PageTable`, in preparation for potential skeleton loading.
2) updated `usePaginationDataFetcher` to accept the `address` and possible `queryParams` as arguments.
3) Update `AccountTransactions` to use the `usePaginationDataFetcher`
4) Fixed a bug where if you refreshed on `AccountTransactions`, it would break the app