### PR TITLE
244 - Nickname edit bug

### DIFF
--- a/src/renderer/components/Icon/index.tsx
+++ b/src/renderer/components/Icon/index.tsx
@@ -14,7 +14,6 @@ import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon';
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon';
 import CloseIcon from 'mdi-react/CloseIcon';
 import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon';
-import EarthIcon from 'mdi-react/EarthIcon';
 import LanConnectIcon from 'mdi-react/LanConnectIcon';
 import LanDisconnectIcon from 'mdi-react/LanDisconnectIcon';
 import LoadingIcon from 'mdi-react/LoadingIcon';
@@ -45,7 +44,6 @@ export enum IconType {
   chevronRight,
   close,
   dotsVertical,
-  earth,
   lanConnect,
   lanDisconnect,
   loading,
@@ -126,8 +124,6 @@ const Icon = forwardRef<HTMLDivElement, ComponentProps>(
           return <CloseIcon {...iconProps} />;
         case IconType.dotsVertical:
           return <DotsVerticalIcon {...iconProps} />;
-        case IconType.earth:
-          return <EarthIcon {...iconProps} />;
         case IconType.lanConnect:
           return <LanConnectIcon {...iconProps} />;
         case IconType.lanDisconnect:

--- a/src/renderer/containers/Account/AccountOverview/index.tsx
+++ b/src/renderer/containers/Account/AccountOverview/index.tsx
@@ -54,7 +54,7 @@ const AccountOverview: FC = () => {
   }, [accountNumber, activePrimaryValidator, dispatch, managedAccount]);
 
   const getItems = () => {
-    let items = [
+    const items = [
       {
         key: 'Balance',
         value: loading ? '-' : managedAccount?.balance || balance || '0',
@@ -66,13 +66,10 @@ const AccountOverview: FC = () => {
     ];
 
     if (managedAccount) {
-      items = [
-        ...items,
-        {
-          key: 'Signing Key',
-          value: renderSigningKey(),
-        },
-      ];
+      items.push({
+        key: 'Signing Key',
+        value: renderSigningKey(),
+      });
     }
 
     return items;

--- a/src/renderer/containers/Account/index.tsx
+++ b/src/renderer/containers/Account/index.tsx
@@ -26,16 +26,18 @@ const Account: FC = () => {
   const managedAccounts = useSelector(getManagedAccounts);
   const managedAccount = managedAccounts[accountNumber];
 
-  const dropdownMenuOptions: DropdownMenuOption[] = [
-    {
-      label: 'Edit Nickname',
-      onClick: toggleEditModal,
-    },
-    {
-      label: 'Delete Account',
-      onClick: toggleDeleteModal,
-    },
-  ];
+  const dropdownMenuOptions: DropdownMenuOption[] = managedAccount
+    ? [
+        {
+          label: 'Edit Nickname',
+          onClick: toggleEditModal,
+        },
+        {
+          label: 'Delete Account',
+          onClick: toggleDeleteModal,
+        },
+      ]
+    : [];
 
   const renderRightPageHeaderButtons = (): ReactNode => <Button onClick={toggleSendPointsModal}>Send Points</Button>;
 

--- a/src/renderer/containers/Account/index.tsx
+++ b/src/renderer/containers/Account/index.tsx
@@ -93,7 +93,11 @@ const Account: FC = () => {
       {deleteModalIsOpen && <DeleteAccountModal close={toggleDeleteModal} managedAccount={managedAccount} />}
       {editModalIsOpen && <EditAccountNicknameModal close={toggleEditModal} managedAccount={managedAccount} />}
       {sendPointsModalIsOpen && (
-        <SendPointsModal close={toggleSendPointsModal} initialRecipient="" initialSender={accountNumber} />
+        <SendPointsModal
+          close={toggleSendPointsModal}
+          initialRecipient={managedAccount ? '' : accountNumber}
+          initialSender={managedAccount ? accountNumber : ''}
+        />
       )}
     </div>
   );

--- a/src/renderer/containers/LeftMenu/index.tsx
+++ b/src/renderer/containers/LeftMenu/index.tsx
@@ -1,7 +1,6 @@
 import React, {FC, ReactNode, useMemo} from 'react';
 import {useSelector} from 'react-redux';
 
-import Icon, {IconType} from '@renderer/components/Icon';
 import CreateAccountModal from '@renderer/containers/Account/CreateAccountModal';
 import AddBankModal from '@renderer/containers/Bank/AddBankModal';
 import AddFriendModal from '@renderer/containers/Friend/AddFriendModal';
@@ -37,14 +36,9 @@ const LeftMenuSelector = (state: RootState) => {
 };
 
 const LeftMenu: FC = () => {
-  const {
-    activePrimaryValidator,
-    managedAccounts,
-    managedBanks,
-    managedFriends,
-    managedValidators,
-    pointBalance,
-  } = useSelector(LeftMenuSelector);
+  const {managedAccounts, managedBanks, managedFriends, managedValidators, pointBalance} = useSelector(
+    LeftMenuSelector,
+  );
   const [addBankModalIsOpen, toggleAddBankModal] = useBooleanState(false);
   const [addFriendModalIsOpen, toggleAddFriendModal] = useBooleanState(false);
   const [addValidatorModalIsOpen, toggleAddValidatorModal] = useBooleanState(false);
@@ -100,24 +94,6 @@ const LeftMenu: FC = () => {
     [managedFriends],
   );
 
-  const networkMenuItems = useMemo<ReactNode[]>(() => {
-    if (!activePrimaryValidator) return [];
-    return [
-      {
-        baseUrl: `/validator/${formatPathFromNode(activePrimaryValidator)}/banks`,
-        key: 'Banks',
-        label: 'Banks',
-        to: `/validator/${formatPathFromNode(activePrimaryValidator)}/banks`,
-      },
-      {
-        baseUrl: `/validator/${formatPathFromNode(activePrimaryValidator)}/validators`,
-        key: 'Validators',
-        label: 'Validators',
-        to: `/validator/${formatPathFromNode(activePrimaryValidator)}/validators`,
-      },
-    ].map(({baseUrl, key, label, to}) => <LeftSubmenuItem baseUrl={baseUrl} key={key} label={label} to={to} />);
-  }, [activePrimaryValidator]);
-
   const validatorMenuItems = useMemo<ReactNode[]>(
     () =>
       Object.values(managedValidators)
@@ -148,7 +124,6 @@ const LeftMenu: FC = () => {
         <div className="points__title">Points</div>
         <div className="points__amount">{pointBalance.toLocaleString()}</div>
       </div>
-      <LeftSubmenu leftIcon={<Icon icon={IconType.earth} size={16} />} menuItems={networkMenuItems} title="Network" />
       <LeftSubmenu menuItems={accountItems} rightOnClick={toggleCreateAccountModal} title="Accounts" />
       <LeftSubmenu menuItems={friendMenuItems} rightOnClick={toggleAddFriendModal} title="Friends" />
       <LeftSubmenu menuItems={bankMenuItems} rightOnClick={toggleAddBankModal} title="Managed Banks" />


### PR DESCRIPTION
- Remove network section on the left menu (users will learn the wrong concepts, those banks and validators belong to the PV)
- Fix bug (app crash) with editing nickname of random account (not managed account or friend) that you navigate to from some table
- Fix bug (app crash) with sending points to random account, default recipient as their account number