### PR TITLE
Fix for changing active bank

### DIFF
--- a/src/renderer/dispatchers/app/index.ts
+++ b/src/renderer/dispatchers/app/index.ts
@@ -1,11 +1,11 @@
 import {
+  changeActiveBank,
   clearManagedAccounts,
   clearManagedBanks,
   clearManagedFriends,
   clearManagedValidators,
   setManagedBank,
   setManagedValidator,
-  changeActiveBank,
   unsetActivePrimaryValidator,
 } from '@renderer/store/app';
 import {AddressData, AppDispatch} from '@renderer/types';

--- a/src/renderer/dispatchers/app/index.ts
+++ b/src/renderer/dispatchers/app/index.ts
@@ -5,7 +5,7 @@ import {
   clearManagedValidators,
   setManagedBank,
   setManagedValidator,
-  unsetActiveBank,
+  changeActiveBank,
   unsetActivePrimaryValidator,
 } from '@renderer/store/app';
 import {AddressData, AppDispatch} from '@renderer/types';
@@ -79,15 +79,15 @@ export const connectAndStoreLocalData = (bankAddressData: AddressData, bankNickn
 
   const activeBankData = {
     ip_address: bankConfig.ip_address,
-    is_default: true,
     nickname: bankNickname,
     nid_signing_key: '',
     node_identifier: bankConfig.node_identifier,
     port: bankConfig.port,
     protocol: bankConfig.protocol,
   };
-  dispatch(unsetActiveBank());
+
   dispatch(setManagedBank(activeBankData));
+  dispatch(changeActiveBank({...activeBankData, is_default: true}));
 
   const activePrimaryValidatorData = {
     ip_address: validatorConfig.ip_address,

--- a/src/renderer/store/app/index.ts
+++ b/src/renderer/store/app/index.ts
@@ -6,7 +6,7 @@ import managedAccounts, {
   setManagedAccountBalance,
   unsetManagedAccount,
 } from './managedAccounts';
-import managedBanks, {clearManagedBanks, setManagedBank, unsetActiveBank, unsetManagedBank} from './managedBanks';
+import managedBanks, {clearManagedBanks, setManagedBank, changeActiveBank, unsetManagedBank} from './managedBanks';
 import managedFriends, {clearManagedFriends, setManagedFriend, unsetManagedFriend} from './managedFriends';
 import managedValidators, {
   clearManagedValidators,
@@ -25,7 +25,7 @@ export {
   setManagedBank,
   setManagedFriend,
   setManagedValidator,
-  unsetActiveBank,
+  changeActiveBank,
   unsetActivePrimaryValidator,
   unsetManagedAccount,
   unsetManagedBank,

--- a/src/renderer/store/app/index.ts
+++ b/src/renderer/store/app/index.ts
@@ -6,7 +6,7 @@ import managedAccounts, {
   setManagedAccountBalance,
   unsetManagedAccount,
 } from './managedAccounts';
-import managedBanks, {clearManagedBanks, setManagedBank, changeActiveBank, unsetManagedBank} from './managedBanks';
+import managedBanks, {changeActiveBank, clearManagedBanks, setManagedBank, unsetManagedBank} from './managedBanks';
 import managedFriends, {clearManagedFriends, setManagedFriend, unsetManagedFriend} from './managedFriends';
 import managedValidators, {
   clearManagedValidators,

--- a/src/renderer/store/app/managedBanks.ts
+++ b/src/renderer/store/app/managedBanks.ts
@@ -7,7 +7,7 @@ import {
   clearLocalAndStateReducer,
   getStateName,
   setLocalAndAddressReducer,
-  unsetActiveNodeReducer,
+  changeActiveNodeReducer,
   unsetLocalAndAddressReducer,
 } from '@renderer/utils/store';
 
@@ -15,13 +15,13 @@ const managedBanks = createSlice({
   initialState: (localStore.get(getStateName(MANAGED_BANKS)) || {}) as Dict<ManagedNode>,
   name: MANAGED_BANKS,
   reducers: {
+    changeActiveBank: changeActiveNodeReducer<ManagedNode>(),
     clearManagedBanks: clearLocalAndStateReducer(),
     setManagedBank: setLocalAndAddressReducer<ManagedNode>(MANAGED_BANKS),
-    unsetActiveBank: unsetActiveNodeReducer(),
     unsetManagedBank: unsetLocalAndAddressReducer(MANAGED_BANKS),
   },
 });
 
-export const {clearManagedBanks, setManagedBank, unsetActiveBank, unsetManagedBank} = managedBanks.actions;
+export const {clearManagedBanks, setManagedBank, changeActiveBank, unsetManagedBank} = managedBanks.actions;
 
 export default managedBanks;

--- a/src/renderer/store/app/managedBanks.ts
+++ b/src/renderer/store/app/managedBanks.ts
@@ -4,10 +4,10 @@ import {MANAGED_BANKS} from '@renderer/constants';
 import localStore from '@renderer/store/localStore';
 import {Dict, ManagedNode} from '@renderer/types';
 import {
+  changeActiveNodeReducer,
   clearLocalAndStateReducer,
   getStateName,
   setLocalAndAddressReducer,
-  changeActiveNodeReducer,
   unsetLocalAndAddressReducer,
 } from '@renderer/utils/store';
 

--- a/src/renderer/utils/store.ts
+++ b/src/renderer/utils/store.ts
@@ -30,6 +30,14 @@ export type SetError = (payload: Address & Error) => PayloadAction<Address & Err
 
 export const getStateName = (actionType: string) => actionType.split('/')[1];
 
+export function changeActiveNodeReducer<T extends ManagedNode>() {
+  return (state: Dict<T>, {payload}: PayloadAction<T>) => {
+    Object.values(state).forEach((node) => {
+      node.is_default = formatAddressFromNode(node) === formatAddressFromNode(payload) && payload.is_default;
+    });
+  };
+}
+
 export const clearLocalAndStateReducer = () => (state: any, action: PayloadAction<undefined>) => {
   localStore.set(getStateName(action.type), {});
   return {};
@@ -139,14 +147,6 @@ export function setPaginatedResultErrorReducer() {
     state[address].next = null;
     state[address].previous = null;
     state[address].results = [];
-  };
-}
-
-export function changeActiveNodeReducer<T extends ManagedNode>() {
-  return (state: Dict<T>, {payload}: PayloadAction<T>) => {
-    Object.values(state).forEach((node) => {
-      node.is_default = formatAddressFromNode(node) === formatAddressFromNode(payload) && payload.is_default;
-    });
   };
 }
 

--- a/src/renderer/utils/store.ts
+++ b/src/renderer/utils/store.ts
@@ -142,6 +142,14 @@ export function setPaginatedResultErrorReducer() {
   };
 }
 
+export function changeActiveNodeReducer<T extends ManagedNode>() {
+  return (state: Dict<T>, {payload}: PayloadAction<T>) => {
+    Object.values(state).forEach((node) => {
+      node.is_default = formatAddressFromNode(node) === formatAddressFromNode(payload) && payload.is_default;
+    });
+  };
+}
+
 export function unsetActiveNodeReducer() {
   return (state: Dict<ManagedNode>) => {
     Object.values(state).forEach((node) => {


### PR DESCRIPTION
Problem was with unsetActiveBank, by setting all banks to is_default: false ideally program forced to show initial screen for default bank entering, but it looped with error. That was happening because component that needed to be updated was already unmounted and console throw this error: 

_Warning: Can’t perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function._

By setting unmonted flag on component would not fix the issue tho. So I changed algorithm that it would add bank if it is not existing and only then switch is_default: true state from one to another in one reducer.

https://github.com/thenewboston-developers/Account-Manager/issues/309