### PR TITLE
Added manageType to AccountLink to navigate dynamically to respective…

### DIFF
--- a/src/renderer/components/AccountLink/index.tsx
+++ b/src/renderer/components/AccountLink/index.tsx
@@ -5,11 +5,12 @@ import './AccountLink.scss';
 
 interface ComponentProps {
   accountNumber: string;
+  managedType: string;
 }
 
-const AccountLink: FC<ComponentProps> = ({accountNumber}) => {
+const AccountLink: FC<ComponentProps> = ({accountNumber, managedType}) => {
   return (
-    <NavLink className="AccountLink" to={`/account/${accountNumber}/overview`}>
+    <NavLink className="AccountLink" to={`/${managedType}/${accountNumber}/overview`}>
       {accountNumber}
     </NavLink>
   );

--- a/src/renderer/constants/index.ts
+++ b/src/renderer/constants/index.ts
@@ -1,4 +1,6 @@
 const APP = 'app';
+export const ACCOUNT = 'account';
+export const FRIEND = 'friend';
 export const BANKS = 'banks';
 export const NOTIFICATIONS = 'notifications';
 export const VALIDATORS = 'validators';

--- a/src/renderer/containers/Account/AccountTransactions/index.tsx
+++ b/src/renderer/containers/Account/AccountTransactions/index.tsx
@@ -5,7 +5,7 @@ import {useParams} from 'react-router-dom';
 import AccountLink from '@renderer/components/AccountLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
-import {BANK_BANK_TRANSACTIONS} from '@renderer/constants';
+import {ACCOUNT, BANK_BANK_TRANSACTIONS} from '@renderer/constants';
 import {usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {getActiveBankConfig} from '@renderer/selectors';
 import {BankTransaction} from '@renderer/types';
@@ -36,8 +36,12 @@ const AccountTransactions: FC = () => {
         [TableKeys.amount]: bankTransaction.amount,
         [TableKeys.balanceKey]: bankTransaction.block.balance_key,
         [TableKeys.dateCreated]: formatDate(bankTransaction.block.created_date),
-        [TableKeys.recipientAccountNumber]: <AccountLink accountNumber={bankTransaction.recipient} />,
-        [TableKeys.senderAccountNumber]: <AccountLink accountNumber={bankTransaction.block.sender} />,
+        [TableKeys.recipientAccountNumber]: (
+          <AccountLink accountNumber={bankTransaction.recipient} managedType={ACCOUNT} />
+        ),
+        [TableKeys.senderAccountNumber]: (
+          <AccountLink accountNumber={bankTransaction.block.sender} managedType={ACCOUNT} />
+        ),
         [TableKeys.signature]: bankTransaction.block.signature,
       })) || [],
     [bankTransactions],

--- a/src/renderer/containers/Bank/BankAccounts/index.tsx
+++ b/src/renderer/containers/Bank/BankAccounts/index.tsx
@@ -5,7 +5,7 @@ import Icon, {IconType} from '@renderer/components/Icon';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import EditTrustModal from '@renderer/containers/EditTrustModal';
-import {BANK_ACCOUNTS} from '@renderer/constants';
+import {ACCOUNT, BANK_ACCOUNTS} from '@renderer/constants';
 import {useAddress, useBooleanState, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {BankAccount, ManagedNode} from '@renderer/types';
 import {formatDate} from '@renderer/utils/dates';
@@ -46,7 +46,7 @@ const BankAccounts: FC<ComponentProps> = ({managedBank}) => {
     () =>
       bankAccounts.map((account) => ({
         key: account.account_number,
-        [TableKeys.accountNumber]: <AccountLink accountNumber={account.account_number} />,
+        [TableKeys.accountNumber]: <AccountLink accountNumber={account.account_number} managedType={ACCOUNT} />,
         [TableKeys.createdDate]: formatDate(account.created_date),
         [TableKeys.id]: account.id,
         [TableKeys.modifiedDate]: formatDate(account.modified_date),

--- a/src/renderer/containers/Bank/BankBanks/index.tsx
+++ b/src/renderer/containers/Bank/BankBanks/index.tsx
@@ -7,7 +7,7 @@ import NodeLink from '@renderer/components/NodeLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import EditTrustModal from '@renderer/containers/EditTrustModal';
-import {BANK_BANKS} from '@renderer/constants';
+import {ACCOUNT, BANK_BANKS} from '@renderer/constants';
 import {useAddress, useBooleanState, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {ManagedNode, Node} from '@renderer/types';
 
@@ -51,7 +51,7 @@ const BankBanks: FC<ComponentProps> = ({managedBank}) => {
     () =>
       bankBanks.map((bank) => ({
         key: bank.node_identifier,
-        [TableKeys.accountNumber]: <AccountLink accountNumber={bank.account_number} />,
+        [TableKeys.accountNumber]: <AccountLink accountNumber={bank.account_number} managedType={ACCOUNT} />,
         [TableKeys.defaultTransactionFee]: bank.default_transaction_fee,
         [TableKeys.ipAddress]: <NodeLink node={bank} urlBase="bank" />,
         [TableKeys.nodeIdentifier]: bank.node_identifier,

--- a/src/renderer/containers/Bank/BankBlocks/index.tsx
+++ b/src/renderer/containers/Bank/BankBlocks/index.tsx
@@ -3,7 +3,7 @@ import React, {FC, useMemo} from 'react';
 import AccountLink from '@renderer/components/AccountLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
-import {BANK_BLOCKS} from '@renderer/constants';
+import {ACCOUNT, BANK_BLOCKS} from '@renderer/constants';
 import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {BlockResponse} from '@renderer/types';
 import {formatDate} from '@renderer/utils/dates';
@@ -31,7 +31,7 @@ const BankBlocks: FC = () => {
         [TableKeys.createdDate]: formatDate(block.created_date),
         [TableKeys.id]: block.id,
         [TableKeys.modifiedDate]: formatDate(block.modified_date),
-        [TableKeys.sender]: <AccountLink accountNumber={block.sender} />,
+        [TableKeys.sender]: <AccountLink accountNumber={block.sender} managedType={ACCOUNT} />,
         [TableKeys.signature]: block.signature,
       })) || [],
     [bankBlocks],

--- a/src/renderer/containers/Bank/BankTransactions/index.tsx
+++ b/src/renderer/containers/Bank/BankTransactions/index.tsx
@@ -3,7 +3,7 @@ import React, {FC, useMemo} from 'react';
 import AccountLink from '@renderer/components/AccountLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
-import {BANK_BANK_TRANSACTIONS} from '@renderer/constants';
+import {ACCOUNT, BANK_BANK_TRANSACTIONS} from '@renderer/constants';
 import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {BankTransaction} from '@renderer/types';
 
@@ -33,8 +33,8 @@ const BankTransactions: FC = () => {
         [TableKeys.amount]: bankTransaction.amount,
         [TableKeys.block]: bankTransaction.block.id,
         [TableKeys.id]: bankTransaction.id,
-        [TableKeys.recipient]: <AccountLink accountNumber={bankTransaction.recipient} />,
-        [TableKeys.sender]: <AccountLink accountNumber={bankTransaction.block.sender} />,
+        [TableKeys.recipient]: <AccountLink accountNumber={bankTransaction.recipient} managedType={ACCOUNT} />,
+        [TableKeys.sender]: <AccountLink accountNumber={bankTransaction.block.sender} managedType={ACCOUNT} />,
       })) || [],
     [bankBankTransactions],
   );

--- a/src/renderer/containers/Bank/BankValidators/index.tsx
+++ b/src/renderer/containers/Bank/BankValidators/index.tsx
@@ -8,7 +8,7 @@ import PageTable, {PageTableData, PageTableItems} from '@renderer/components/Pag
 import Pagination from '@renderer/components/Pagination';
 import EditTrustModal from '@renderer/containers/EditTrustModal';
 import PurchaseConfirmationServicesModal from '@renderer/containers/PurchaseConfirmationServicesModal';
-import {BANK_VALIDATORS} from '@renderer/constants';
+import {ACCOUNT, BANK_VALIDATORS} from '@renderer/constants';
 import {useAddress, useBooleanState, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {getActivePrimaryValidatorConfig} from '@renderer/selectors';
 import {BaseValidator, ManagedNode} from '@renderer/types';
@@ -83,7 +83,7 @@ const BankValidators: FC<ComponentProps> = ({managedBank}) => {
     () =>
       bankValidators.map((validator) => ({
         key: validator.node_identifier,
-        [TableKeys.accountNumber]: <AccountLink accountNumber={validator.account_number} />,
+        [TableKeys.accountNumber]: <AccountLink accountNumber={validator.account_number} managedType={ACCOUNT} />,
         [TableKeys.dailyConfirmationRate]: renderValidatorDailyRate(validator),
         [TableKeys.defaultTransactionFee]: validator.default_transaction_fee,
         [TableKeys.ipAddress]: <NodeLink node={validator} urlBase="validator" />,

--- a/src/renderer/containers/Friend/index.tsx
+++ b/src/renderer/containers/Friend/index.tsx
@@ -25,7 +25,6 @@ const Friend: FC = () => {
   const [sendPointsModalIsOpen, toggleSendPointsModal] = useBooleanState(false);
   const managedFriends = useSelector(getManagedFriends);
   const managedFriend = managedFriends[accountNumber];
-
   const getDropdownMenuOptions = (): DropdownMenuOption[] => {
     if (!managedFriend) return [];
     return [

--- a/src/renderer/containers/Validator/ValidatorAccounts/index.tsx
+++ b/src/renderer/containers/Validator/ValidatorAccounts/index.tsx
@@ -3,7 +3,7 @@ import React, {FC, useMemo} from 'react';
 import AccountLink from '@renderer/components/AccountLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
-import {VALIDATOR_ACCOUNTS} from '@renderer/constants';
+import {ACCOUNT, VALIDATOR_ACCOUNTS} from '@renderer/constants';
 import {useAddress, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {ValidatorAccount} from '@renderer/types';
 
@@ -23,7 +23,7 @@ const ValidatorAccounts: FC = () => {
     () =>
       validatorAccounts.map((account) => ({
         key: account.id,
-        [TableKeys.accountNumber]: <AccountLink accountNumber={account.account_number} />,
+        [TableKeys.accountNumber]: <AccountLink accountNumber={account.account_number} managedType={ACCOUNT} />,
         [TableKeys.balanceLock]: account.balance_lock,
         [TableKeys.balance]: account.balance,
       })) || [],

--- a/src/renderer/containers/Validator/ValidatorBanks/index.tsx
+++ b/src/renderer/containers/Validator/ValidatorBanks/index.tsx
@@ -6,7 +6,7 @@ import NodeLink from '@renderer/components/NodeLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import EditTrustModal from '@renderer/containers/EditTrustModal';
-import {VALIDATOR_BANKS} from '@renderer/constants';
+import {ACCOUNT, VALIDATOR_BANKS} from '@renderer/constants';
 import {useAddress, useBooleanState, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {ManagedNode, Node, ValidatorBank} from '@renderer/types';
 
@@ -50,7 +50,7 @@ const ValidatorBanks: FC<ComponentProps> = ({managedValidator}) => {
     () =>
       validatorBanks.map((bank) => ({
         key: bank.node_identifier,
-        [TableKeys.accountNumber]: <AccountLink accountNumber={bank.account_number} />,
+        [TableKeys.accountNumber]: <AccountLink accountNumber={bank.account_number} managedType={ACCOUNT} />,
         [TableKeys.confirmationExpiration]: bank.confirmation_expiration,
         [TableKeys.defaultTransactionFee]: bank.default_transaction_fee,
         [TableKeys.ipAddress]: <NodeLink node={bank} urlBase="bank" />,

--- a/src/renderer/containers/Validator/ValidatorValidators/index.tsx
+++ b/src/renderer/containers/Validator/ValidatorValidators/index.tsx
@@ -6,7 +6,7 @@ import NodeLink from '@renderer/components/NodeLink';
 import PageTable, {PageTableData, PageTableItems} from '@renderer/components/PageTable';
 import Pagination from '@renderer/components/Pagination';
 import EditTrustModal from '@renderer/containers/EditTrustModal';
-import {VALIDATOR_VALIDATORS} from '@renderer/constants';
+import {ACCOUNT, VALIDATOR_VALIDATORS} from '@renderer/constants';
 import {useAddress, useBooleanState, usePaginatedNetworkDataFetcher} from '@renderer/hooks';
 import {BaseValidator, ManagedNode} from '@renderer/types';
 
@@ -58,7 +58,7 @@ const ValidatorValidators: FC<ComponentProps> = ({managedValidator}) => {
     () =>
       validatorValidators.map((validator) => ({
         key: validator.node_identifier,
-        [TableKeys.accountNumber]: <AccountLink accountNumber={validator.account_number} />,
+        [TableKeys.accountNumber]: <AccountLink accountNumber={validator.account_number} managedType={ACCOUNT} />,
         [TableKeys.dailyConfirmationRate]: validator.daily_confirmation_rate,
         [TableKeys.defaultTransactionFee]: validator.default_transaction_fee,
         [TableKeys.ipAddress]: <NodeLink node={validator} urlBase="validator" />,


### PR DESCRIPTION
Proposed fix for #363 

**Changes made:-**
1) Introduced `ACCOUNT` and `FRIEND` constant.
2) I have added a `manageType` to `AccountLink `component to navigate to respective link.
3) In `FriendTransactions`, for each **recipient** and **sender**, we get their respective `manageType` and pass down to `AccountLink` component.

**After these changes :-** 
For all **Validators**, **Banks** and **Accounts** - the user will always route to **Account** overview.
But if the **user is in Friend Transactions**, he/she will move to **Friend** overview if a friend account number is clicked else the **Account** overview.