### PR TITLE
Disable mark all as read text if notifications is empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "thenewboston",
-  "version": "1.0.0-alpha.15",
+  "version": "1.0.0-alpha.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "thenewboston",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-alpha.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/renderer/components/DropdownMenuButton/index.tsx
+++ b/src/renderer/components/DropdownMenuButton/index.tsx
@@ -68,18 +68,20 @@ const DropdownMenuButton: FC<ComponentProps> = ({className, direction = Dropdown
     closeMenu();
   };
 
-  const handleOptionKeyDown = (optionOnClick: GenericVoidFunction, index: number) => async (
+  const handleOptionKeyDown = (optionOnClick: GenericVoidFunction, index: number, disabled: boolean) => async (
     e: KeyboardEvent<HTMLDivElement>,
   ): Promise<void> => {
     if (index !== options.length - 1 && e.key === 'ArrowDown') {
       optionsRef.current[index + 1]?.focus();
       return;
     }
+
     if (index !== 0 && e.key === 'ArrowUp') {
       optionsRef.current[index - 1]?.focus();
       return;
     }
-    if (e.key === 'Enter') {
+
+    if (e.key === 'Enter' && !disabled) {
       await optionOnClick();
       closeMenu();
     }
@@ -110,7 +112,7 @@ const DropdownMenuButton: FC<ComponentProps> = ({className, direction = Dropdown
                     ...getCustomClassNames(className, '__option--disabled', disabled),
                   })}
                   key={JSON.stringify(label)}
-                  onKeyDown={disabled ? noop : handleOptionKeyDown(optionOnClick, index)}
+                  onKeyDown={handleOptionKeyDown(optionOnClick, index, disabled)}
                   onClick={disabled ? noop : handleOptionClick(optionOnClick)}
                   ref={(el) => {
                     if (el) {

--- a/src/renderer/components/DropdownMenuButton/index.tsx
+++ b/src/renderer/components/DropdownMenuButton/index.tsx
@@ -71,12 +71,12 @@ const DropdownMenuButton: FC<ComponentProps> = ({className, direction = Dropdown
   const handleOptionKeyDown = (optionOnClick: GenericVoidFunction, index: number, disabled: boolean) => async (
     e: KeyboardEvent<HTMLDivElement>,
   ): Promise<void> => {
-    if (index !== options.length - 1 && e.key === 'ArrowDown') {
+    if (e.key === 'ArrowDown' && index !== options.length - 1) {
       optionsRef.current[index + 1]?.focus();
       return;
     }
 
-    if (index !== 0 && e.key === 'ArrowUp') {
+    if (e.key === 'ArrowUp' && index !== 0) {
       optionsRef.current[index - 1]?.focus();
       return;
     }

--- a/src/renderer/containers/Notifications/NotificationsMenu/NotificationsMenu.scss
+++ b/src/renderer/containers/Notifications/NotificationsMenu/NotificationsMenu.scss
@@ -44,9 +44,18 @@
   &__mark-as-read {
     color: var(--color-secondary);
     cursor: pointer;
-
     &:hover {
       text-decoration: underline;
+    }
+  }
+
+  &__mark-as-read-disabled {
+    color: var(--color-gray-300);
+    cursor: default;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
     }
   }
 }

--- a/src/renderer/containers/Notifications/NotificationsMenu/NotificationsMenu.scss
+++ b/src/renderer/containers/Notifications/NotificationsMenu/NotificationsMenu.scss
@@ -44,18 +44,19 @@
   &__mark-as-read {
     color: var(--color-secondary);
     cursor: pointer;
+
     &:hover {
       text-decoration: underline;
     }
-  }
 
-  &__mark-as-read-disabled {
-    color: var(--color-gray-300);
-    cursor: default;
-    text-decoration: none;
-
-    &:hover {
+    &--disabled {
+      color: var(--color-gray-300);
+      cursor: default;
       text-decoration: none;
+
+      &:hover {
+        text-decoration: none;
+      }
     }
   }
 }

--- a/src/renderer/containers/Notifications/NotificationsMenu/index.tsx
+++ b/src/renderer/containers/Notifications/NotificationsMenu/index.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactNode, RefObject, useRef, useState} from 'react';
+import React, {FC, ReactNode, RefObject, useRef} from 'react';
 import noop from 'lodash/noop';
 
 import {useEventListener} from '@renderer/hooks';
@@ -24,12 +24,8 @@ const NotificationsMenu: FC<ComponentProps> = ({
   updateLastReadTime,
 }) => {
   const menuRef = useRef<HTMLDivElement>(null);
-  const [emptyNotification, setEmptyNotification] = useState(true);
 
   const handleClick = (e: any): void => {
-    if (unreadNotificationsLength !== 0) {
-      setEmptyNotification(!emptyNotification);
-    }
     if (menuOpen && !iconRef.current?.contains(e.target) && !menuRef.current?.contains(e.target)) {
       handleMenuClose();
     }
@@ -46,9 +42,9 @@ const NotificationsMenu: FC<ComponentProps> = ({
         </div>
         <span
           className={clsx('NotificationsMenu__mark-as-read', {
-            'NotificationsMenu__mark-as-read-disabled': emptyNotification,
+            'NotificationsMenu__mark-as-read--disabled': !unreadNotificationsLength,
           })}
-          onClick={emptyNotification ? noop : updateLastReadTime}
+          onClick={unreadNotificationsLength ? updateLastReadTime : noop}
         >
           Mark all as read
         </span>

--- a/src/renderer/containers/Notifications/NotificationsMenu/index.tsx
+++ b/src/renderer/containers/Notifications/NotificationsMenu/index.tsx
@@ -1,10 +1,10 @@
 import React, {FC, ReactNode, RefObject, useRef} from 'react';
 import noop from 'lodash/noop';
+import clsx from 'clsx';
 
 import {useEventListener} from '@renderer/hooks';
 
 import './NotificationsMenu.scss';
-import clsx from 'clsx';
 
 interface ComponentProps {
   handleMenuClose(): void;

--- a/src/renderer/containers/Notifications/NotificationsMenu/index.tsx
+++ b/src/renderer/containers/Notifications/NotificationsMenu/index.tsx
@@ -1,8 +1,10 @@
-import React, {FC, ReactNode, RefObject, useRef} from 'react';
+import React, {FC, ReactNode, RefObject, useRef, useState} from 'react';
+import noop from 'lodash/noop';
 
 import {useEventListener} from '@renderer/hooks';
 
 import './NotificationsMenu.scss';
+import clsx from 'clsx';
 
 interface ComponentProps {
   handleMenuClose(): void;
@@ -22,8 +24,12 @@ const NotificationsMenu: FC<ComponentProps> = ({
   updateLastReadTime,
 }) => {
   const menuRef = useRef<HTMLDivElement>(null);
+  const [emptyNotification, setEmptyNotification] = useState(true);
 
   const handleClick = (e: any): void => {
+    if (unreadNotificationsLength !== 0) {
+      setEmptyNotification(!emptyNotification);
+    }
     if (menuOpen && !iconRef.current?.contains(e.target) && !menuRef.current?.contains(e.target)) {
       handleMenuClose();
     }
@@ -38,7 +44,12 @@ const NotificationsMenu: FC<ComponentProps> = ({
           <h2>Notifications</h2>
           <span className="NotificationsMenu__count">{unreadNotificationsLength} unread</span>
         </div>
-        <span className="NotificationsMenu__mark-as-read" onClick={updateLastReadTime}>
+        <span
+          className={clsx('NotificationsMenu__mark-as-read', {
+            'NotificationsMenu__mark-as-read-disabled': emptyNotification,
+          })}
+          onClick={emptyNotification ? noop : updateLastReadTime}
+        >
           Mark all as read
         </span>
       </div>


### PR DESCRIPTION
Instead of removing it every time the notification modal is opened it checks for the unread notifications. If it is empty, nothing happens when clicking on `Mark all as read`. @buckyroberts I wanted to test it locally but I am not sure what exactly triggers a notification. 
Fixes #361 