### PR TITLE
Limit amount of coins that can be sent

### DIFF
--- a/src/renderer/containers/SendCoinsModal/index.tsx
+++ b/src/renderer/containers/SendCoinsModal/index.tsx
@@ -96,6 +96,7 @@ const SendCoinsModal: FC<ComponentProps> = ({close, initialRecipient, initialSen
         .number()
         .callbackWithRef(senderAccountNumberRef, checkCoinsWithBalance, INVALID_AMOUNT_ERROR)
         .moreThan(0, 'Coins must be greater than 0')
+        .lessThan(9000000000000000, 'Coins must be lower than 9,000,000,000,000,000') // Less than Number.MAX_SAFE_INTEGER
         .integer('Coins cannot be a decimal')
         .required('Coins is a required field'),
       recipientAccountNumber: yup


### PR DESCRIPTION
Fixes #438 by adding a cap to the maximum amount of coins that can be entered for a single transaction.

The maximum number is lower than `Number.MAX_SAFE_INTEGER` and yet higher than the [max supply](https://thenewboston.com/faq).

**Account Number:**
f44a787b4f741279759b47667ad4083edd16bd7e422104e4236cd0ce996a1a7d