### PR TITLE
Add 64 char limit for nicknames

### DIFF
--- a/src/renderer/constants/form-validation.ts
+++ b/src/renderer/constants/form-validation.ts
@@ -1,2 +1,5 @@
+export const NICKNAME_MAX_LENGTH = 64;
+export const NICKNAME_MAX_LENGTH_ERROR = 'Nickname must not be more than 64 characters';
+
 export const SIGNING_KEY_LENGTH_ERROR = 'Signing key must be 64 characters long';
 export const SIGNING_KEY_REQUIRED_ERROR = 'Signing key is required';

--- a/src/renderer/containers/Account/CreateAccountModal/index.tsx
+++ b/src/renderer/containers/Account/CreateAccountModal/index.tsx
@@ -91,7 +91,10 @@ const CreateAccountModal: FC<ComponentProps> = ({close, isGetStartedModal = fals
 
   const validationSchema = useMemo(() => {
     return yup.object().shape({
-      nickname: yup.string().notOneOf(managedAccountNicknames, 'That nickname is already taken'),
+      nickname: yup
+        .string()
+        .notOneOf(managedAccountNicknames, 'That nickname is already taken')
+        .max(64, 'Nickname must not be more than 64 characters.'),
       signingKey: yup.string().when('type', {
         is: 'create',
         otherwise: yup

--- a/src/renderer/containers/Account/CreateAccountModal/index.tsx
+++ b/src/renderer/containers/Account/CreateAccountModal/index.tsx
@@ -4,7 +4,12 @@ import {useHistory} from 'react-router-dom';
 import axios from 'axios';
 
 import Modal from '@renderer/components/Modal';
-import {SIGNING_KEY_LENGTH_ERROR, SIGNING_KEY_REQUIRED_ERROR} from '@renderer/constants/form-validation';
+import {
+  NICKNAME_MAX_LENGTH,
+  NICKNAME_MAX_LENGTH_ERROR,
+  SIGNING_KEY_LENGTH_ERROR,
+  SIGNING_KEY_REQUIRED_ERROR,
+} from '@renderer/constants/form-validation';
 import {getActivePrimaryValidator, getManagedAccounts} from '@renderer/selectors';
 import {setManagedAccount} from '@renderer/store/app';
 import {AppDispatch} from '@renderer/types';
@@ -94,7 +99,7 @@ const CreateAccountModal: FC<ComponentProps> = ({close, isGetStartedModal = fals
       nickname: yup
         .string()
         .notOneOf(managedAccountNicknames, 'That nickname is already taken')
-        .max(64, 'Nickname must not be more than 64 characters.'),
+        .max(NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR),
       signingKey: yup.string().when('type', {
         is: 'create',
         otherwise: yup

--- a/src/renderer/containers/Account/EditAccountNicknameModal/index.tsx
+++ b/src/renderer/containers/Account/EditAccountNicknameModal/index.tsx
@@ -31,7 +31,10 @@ const EditAccountNicknameModal: FC<ComponentProps> = ({close, managedAccount}) =
 
   const validationSchema = useMemo(() => {
     return yup.object().shape({
-      nickname: yup.string().notOneOf(managedAccountNicknames, 'That nickname is already taken'),
+      nickname: yup
+        .string()
+        .notOneOf(managedAccountNicknames, 'That nickname is already taken')
+        .max(64, 'Nickname must not be more than 64 characters.'),
     });
   }, [managedAccountNicknames]);
 

--- a/src/renderer/containers/Account/EditAccountNicknameModal/index.tsx
+++ b/src/renderer/containers/Account/EditAccountNicknameModal/index.tsx
@@ -2,6 +2,7 @@ import React, {FC, useMemo} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import Modal from '@renderer/components/Modal';
 import {FormInput} from '@renderer/components/FormComponents';
+import {NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR} from '@renderer/constants/form-validation';
 import {getManagedAccounts} from '@renderer/selectors';
 import {setManagedAccount} from '@renderer/store/app';
 import {AppDispatch, ManagedAccount} from '@renderer/types';
@@ -34,7 +35,7 @@ const EditAccountNicknameModal: FC<ComponentProps> = ({close, managedAccount}) =
       nickname: yup
         .string()
         .notOneOf(managedAccountNicknames, 'That nickname is already taken')
-        .max(64, 'Nickname must not be more than 64 characters.'),
+        .max(NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR),
     });
   }, [managedAccountNicknames]);
 

--- a/src/renderer/containers/Bank/AddBankModal/index.tsx
+++ b/src/renderer/containers/Bank/AddBankModal/index.tsx
@@ -3,6 +3,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import {useHistory} from 'react-router-dom';
 
 import Modal from '@renderer/components/Modal';
+import {NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR} from '@renderer/constants/form-validation';
 import {fetchBankConfig} from '@renderer/dispatchers/banks';
 import {getManagedBanks} from '@renderer/selectors';
 import {setManagedBank} from '@renderer/store/app';
@@ -102,7 +103,7 @@ const AddBankModal: FC<ComponentProps> = ({close}) => {
       nickname: yup
         .string()
         .notOneOf(managedBankNicknames, 'That nickname is already taken')
-        .max(64, 'Nickname must not be more than 64 characters.'),
+        .max(NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR),
       port: yup.number().integer(),
       protocol: yup.string().required(),
     });

--- a/src/renderer/containers/Bank/AddBankModal/index.tsx
+++ b/src/renderer/containers/Bank/AddBankModal/index.tsx
@@ -99,7 +99,10 @@ const AddBankModal: FC<ComponentProps> = ({close}) => {
         .string()
         .required('This field is required')
         .matches(genericIpAddressRegex, {excludeEmptyString: true, message: 'IPv4 or IPv6 addresses only'}),
-      nickname: yup.string().notOneOf(managedBankNicknames, 'That nickname is already taken'),
+      nickname: yup
+        .string()
+        .notOneOf(managedBankNicknames, 'That nickname is already taken')
+        .max(64, 'Nickname must not be more than 64 characters.'),
       port: yup.number().integer(),
       protocol: yup.string().required(),
     });

--- a/src/renderer/containers/Bank/EditBankNicknameModal/index.tsx
+++ b/src/renderer/containers/Bank/EditBankNicknameModal/index.tsx
@@ -33,7 +33,10 @@ const EditBankNicknameModal: FC<ComponentProps> = ({bank, close}) => {
 
   const validationSchema = useMemo(() => {
     return yup.object().shape({
-      nickname: yup.string().notOneOf(managedBankNicknames, 'That nickname is already taken'),
+      nickname: yup
+        .string()
+        .notOneOf(managedBankNicknames, 'That nickname is already taken')
+        .max(64, 'Nickname must not be more than 64 characters.'),
     });
   }, [managedBankNicknames]);
 

--- a/src/renderer/containers/Bank/EditBankNicknameModal/index.tsx
+++ b/src/renderer/containers/Bank/EditBankNicknameModal/index.tsx
@@ -3,6 +3,7 @@ import {useDispatch, useSelector} from 'react-redux';
 
 import {FormInput} from '@renderer/components/FormComponents';
 import Modal from '@renderer/components/Modal';
+import {NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR} from '@renderer/constants/form-validation';
 import {setManagedBank} from '@renderer/store/app';
 import {getManagedBanks} from '@renderer/selectors';
 import {AppDispatch, ManagedNode} from '@renderer/types';
@@ -36,7 +37,7 @@ const EditBankNicknameModal: FC<ComponentProps> = ({bank, close}) => {
       nickname: yup
         .string()
         .notOneOf(managedBankNicknames, 'That nickname is already taken')
-        .max(64, 'Nickname must not be more than 64 characters.'),
+        .max(NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR),
     });
   }, [managedBankNicknames]);
 

--- a/src/renderer/containers/Friend/AddFriendModal/index.tsx
+++ b/src/renderer/containers/Friend/AddFriendModal/index.tsx
@@ -75,7 +75,10 @@ const AddFriendModal: FC<ComponentProps> = ({close}) => {
         .test('friend-already-exists', "This friend's account already exists", (accountNumber) => {
           return !managedFriendsAccountNumbers.includes(accountNumber || '');
         }),
-      nickname: yup.string().notOneOf(managedFriendNicknames, 'That nickname is already taken'),
+      nickname: yup
+        .string()
+        .notOneOf(managedFriendNicknames, 'That nickname is already taken')
+        .max(64, 'Nickname must not be more than 64 characters.'),
     });
   }, [managedAccountNumbers, managedFriendsAccountNumbers, managedFriendNicknames]);
 

--- a/src/renderer/containers/Friend/AddFriendModal/index.tsx
+++ b/src/renderer/containers/Friend/AddFriendModal/index.tsx
@@ -4,6 +4,7 @@ import {useHistory} from 'react-router-dom';
 
 import {FormInput, FormTextArea} from '@renderer/components/FormComponents';
 import Modal from '@renderer/components/Modal';
+import {NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR} from '@renderer/constants/form-validation';
 import {getManagedAccounts, getManagedFriends} from '@renderer/selectors';
 import {setManagedFriend} from '@renderer/store/app';
 import {AppDispatch} from '@renderer/types';
@@ -78,7 +79,7 @@ const AddFriendModal: FC<ComponentProps> = ({close}) => {
       nickname: yup
         .string()
         .notOneOf(managedFriendNicknames, 'That nickname is already taken')
-        .max(64, 'Nickname must not be more than 64 characters.'),
+        .max(NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR),
     });
   }, [managedAccountNumbers, managedFriendsAccountNumbers, managedFriendNicknames]);
 

--- a/src/renderer/containers/Friend/EditFriendNicknameModal/index.tsx
+++ b/src/renderer/containers/Friend/EditFriendNicknameModal/index.tsx
@@ -3,6 +3,7 @@ import {useDispatch, useSelector} from 'react-redux';
 
 import Modal from '@renderer/components/Modal';
 import {FormInput} from '@renderer/components/FormComponents';
+import {NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR} from '@renderer/constants/form-validation';
 import {getManagedFriends} from '@renderer/selectors';
 import {setManagedFriend} from '@renderer/store/app';
 import {AppDispatch, ManagedFriend} from '@renderer/types';
@@ -49,7 +50,7 @@ const EditFriendNicknameModal: FC<ComponentProps> = ({close, managedFriend}) => 
       nickname: yup
         .string()
         .notOneOf(managedFriendsNicknames, 'That nickname is already taken')
-        .max(64, 'Nickname must not be more than 64 characters.'),
+        .max(NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR),
     });
   }, [managedFriendsNicknames]);
 

--- a/src/renderer/containers/Friend/EditFriendNicknameModal/index.tsx
+++ b/src/renderer/containers/Friend/EditFriendNicknameModal/index.tsx
@@ -46,7 +46,10 @@ const EditFriendNicknameModal: FC<ComponentProps> = ({close, managedFriend}) => 
 
   const validationSchema = useMemo(() => {
     return yup.object().shape({
-      nickname: yup.string().notOneOf(managedFriendsNicknames, 'That nickname is already taken'),
+      nickname: yup
+        .string()
+        .notOneOf(managedFriendsNicknames, 'That nickname is already taken')
+        .max(64, 'Nickname must not be more than 64 characters.'),
     });
   }, [managedFriendsNicknames]);
 

--- a/src/renderer/containers/Validator/AddValidatorModal/index.tsx
+++ b/src/renderer/containers/Validator/AddValidatorModal/index.tsx
@@ -100,7 +100,10 @@ const AddValidatorModal: FC<ComponentProps> = ({close}) => {
         .string()
         .required('This field is required')
         .matches(genericIpAddressRegex, {excludeEmptyString: true, message: 'IPv4 or IPv6 addresses only'}),
-      nickname: yup.string().notOneOf(managedValidatorNicknames, 'That nickname is already taken'),
+      nickname: yup
+        .string()
+        .notOneOf(managedValidatorNicknames, 'That nickname is already taken')
+        .max(64, 'Nickname must not be more than 64 characters.'),
       port: yup.number().integer(),
       protocol: yup.string().required(),
     });

--- a/src/renderer/containers/Validator/AddValidatorModal/index.tsx
+++ b/src/renderer/containers/Validator/AddValidatorModal/index.tsx
@@ -3,6 +3,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import {useHistory} from 'react-router-dom';
 
 import Modal from '@renderer/components/Modal';
+import {NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR} from '@renderer/constants/form-validation';
 import {fetchValidatorConfig} from '@renderer/dispatchers/validators';
 import {getManagedValidators} from '@renderer/selectors';
 import {setManagedValidator} from '@renderer/store/app';
@@ -103,7 +104,7 @@ const AddValidatorModal: FC<ComponentProps> = ({close}) => {
       nickname: yup
         .string()
         .notOneOf(managedValidatorNicknames, 'That nickname is already taken')
-        .max(64, 'Nickname must not be more than 64 characters.'),
+        .max(NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR),
       port: yup.number().integer(),
       protocol: yup.string().required(),
     });

--- a/src/renderer/containers/Validator/EditValidatorNicknameModal/index.tsx
+++ b/src/renderer/containers/Validator/EditValidatorNicknameModal/index.tsx
@@ -46,7 +46,10 @@ const EditValidatorNicknameModal: FC<ComponentProps> = ({close, validator}) => {
 
   const validationSchema = useMemo(() => {
     return yup.object().shape({
-      nickname: yup.string().notOneOf(managedValidatorNicknames, 'That nickname is already taken'),
+      nickname: yup
+        .string()
+        .notOneOf(managedValidatorNicknames, 'That nickname is already taken')
+        .max(64, 'Nickname must not be more than 64 characters.'),
     });
   }, [managedValidatorNicknames]);
 

--- a/src/renderer/containers/Validator/EditValidatorNicknameModal/index.tsx
+++ b/src/renderer/containers/Validator/EditValidatorNicknameModal/index.tsx
@@ -3,6 +3,7 @@ import {useDispatch, useSelector} from 'react-redux';
 
 import {FormInput} from '@renderer/components/FormComponents';
 import Modal from '@renderer/components/Modal';
+import {NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR} from '@renderer/constants/form-validation';
 import {getManagedValidators} from '@renderer/selectors';
 import {setManagedValidator} from '@renderer/store/app';
 import {AppDispatch, ManagedNode} from '@renderer/types';
@@ -49,7 +50,7 @@ const EditValidatorNicknameModal: FC<ComponentProps> = ({close, validator}) => {
       nickname: yup
         .string()
         .notOneOf(managedValidatorNicknames, 'That nickname is already taken')
-        .max(64, 'Nickname must not be more than 64 characters.'),
+        .max(NICKNAME_MAX_LENGTH, NICKNAME_MAX_LENGTH_ERROR),
     });
   }, [managedValidatorNicknames]);
 


### PR DESCRIPTION
Fixes #494 

Added max 64 limit to:
- Create account
- Edit account nickname
- Add bank
- Edit bank nickname
- Add friend
- Edit friend nickname
- Add validator
- Edit validator nickname

Acc: c54c04774efaae20746fd3f29cdd619fea512e119bc1082b863572b2e8844104