### PR TITLE
fixing Add 'Bank/Validator' button active with empty required fields.

### DIFF
--- a/src/renderer/components/Modal/index.tsx
+++ b/src/renderer/components/Modal/index.tsx
@@ -86,7 +86,7 @@ const Modal: FC<ComponentProps> = ({
     if (typeof submitButton === 'string') {
       return {
         content: submitButton,
-        ignoreDirty,
+        ignoreDirty: false,
         submitting,
         type: 'submit',
       };


### PR DESCRIPTION
Fixing a bug, I initialized the "ignoreDirty" with false at first unlike the cancel button that have the default behavior and needs to stay active. So now the problem is solved for all the "Add" buttons, I tested it in the Add Bank and Add Validator and it works just fine. After entering all the required fields, the Add button is active else the Add button is disabled.

This solves #482 👍 

Account Number: 5df2dd6f48a69681cd3b55b416a53da1aa831a28cf35c7b6c48a0e39b19c8b92