### PR TITLE
Fixes Multiple Instances

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -31,10 +31,12 @@ const createWindow = (): void => {
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
 };
 
+// if gotTheLock is false, another instance of application is already running
 if (!gotTheLock) {
   app.quit();
 } else {
   app.on('second-instance', () => {
+    // focus back to the previous instance, if someone tried to create new instance
     if (mainWindow) {
       if (mainWindow.isMinimized() || !mainWindow.isFocused()) {
         mainWindow.restore();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,6 +10,7 @@ import menu from './menu';
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 
 const isMac = process.platform === 'darwin';
+const gotTheLock = app.requestSingleInstanceLock();
 
 Menu.setApplicationMenu(menu);
 
@@ -30,15 +31,26 @@ const createWindow = (): void => {
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
 };
 
+if (!gotTheLock) {
+  app.quit();
+} else {
+  app.on('second-instance', () => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized() || !mainWindow.isFocused()) {
+        mainWindow.restore();
+        mainWindow.focus();
+      }
+    }
+  });
+  app.whenReady().then(() => {
+    installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS])
+      .then((name) => console.log(`Added Extension: ${name}`))
+      .catch((error) => console.log('An error occurred: ', error));
+  });
+  app.on('ready', createWindow);
+}
+
 app.setName('TNB Account Manager');
-
-app.whenReady().then(() => {
-  installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS])
-    .then((name) => console.log(`Added Extension: ${name}`))
-    .catch((error) => console.log('An error occurred: ', error));
-});
-
-app.on('ready', createWindow);
 
 app.on('window-all-closed', () => {
   // On OS X it is common for applications and their menu bar


### PR DESCRIPTION
Fix: https://github.com/thenewboston-developers/Account-Manager/issues/593

- Prevents the creation of multiple instances on clicking the launcher icon multiple times.
- Instead of creating new instances, focus back on the minimised or off-focused window.

**Screen Recording:**

![acc-mngr-bug-fix](https://user-images.githubusercontent.com/22790904/110761074-53952580-8275-11eb-8691-fb140ade828d.gif)



Account Number: `0f92e975101eb96cea80dce430d74efd3172fa229377818d467ded85dcf2ab6c`